### PR TITLE
Update LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,6 @@
 MIT License
 
 Copyright (c) 2018 Tristano Ajmone
-https://github.com/highlightjs/highlightjs-alan
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Is URL required?  This causes GitHub's license matching to fail...